### PR TITLE
Track Non-TCP connections in open_conn log

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 By default, Zeek will only log connection information after the connection as been closed or Zeek has been stopped. This means that long running connections could run for hours, days, or even weeks before they are noticed. For threat hunters, this behavior is highly undesirable.
 
-This Zeek plugin will cause Zeek to periodically write out connection information for open connections. The information is written out to a file named "conn_log.log". The information written to the log file is identical to what is written to conn.log. Each entry contains the TOTAL duration and bytes transferred by the open connection.
+This Zeek plugin will cause Zeek to periodically write out connection information for open connections. The information is written out to a file named "open_conn.log". The information written to the log file is identical to what is written to conn.log. Each entry contains the TOTAL duration and bytes transferred by the open connection.
 
 The entries are written out at an interval that is specified by the user. The default interval is to write out an entry after the connection has been open for 1 hour and then every hour after that first hour.
 

--- a/scripts/zeek_open_connections.zeek
+++ b/scripts/zeek_open_connections.zeek
@@ -89,12 +89,16 @@ function long_callback(c: connection, cnt: count): interval
                 return ALERT_INTERVAL - c$duration;
         }
 
-event connection_established(c: connection)
+#Prefer connection_successful to new_connection in order to filter out SYN scans
+#https://github.com/zeek/zeek/blob/release/3.1/CHANGES#L1279
+@if ( Version::number >= 30100 )
+#https://docs.zeek.org/en/v3.1.0/scripts/base/bif/event.bif.zeek.html#id-connection_successful
+event connection_successful(c: connection)
+@else
+#https://docs.zeek.org/en/v3.1.0/scripts/base/bif/event.bif.zeek.html#id-new_connection
+event new_connection(c: connection)
+@endif
         {
                 ConnPolling::watch(c, long_callback, 1, ALERT_INTERVAL);
         }
 
-event partial_connection(c: connection)
-        {
-                ConnPolling::watch(c, long_callback, 1, ALERT_INTERVAL);
-        }

--- a/scripts/zeek_open_connections.zeek
+++ b/scripts/zeek_open_connections.zeek
@@ -72,7 +72,7 @@ redef record connection += {
 
 event zeek_init() &priority=5
         {
-        Log::create_stream(LOG, [$columns=Conn::Info, $path="conn_long"]);
+        Log::create_stream(LOG, [$columns=Conn::Info, $path="open_conn"]);
         }
 
 
@@ -89,15 +89,8 @@ function long_callback(c: connection, cnt: count): interval
                 return ALERT_INTERVAL - c$duration;
         }
 
-#Prefer connection_successful to new_connection in order to filter out SYN scans
-#https://github.com/zeek/zeek/blob/release/3.1/CHANGES#L1279
-@if ( Version::number >= 30100 )
-#https://docs.zeek.org/en/v3.1.0/scripts/base/bif/event.bif.zeek.html#id-connection_successful
-event connection_successful(c: connection)
-@else
-#https://docs.zeek.org/en/v3.1.0/scripts/base/bif/event.bif.zeek.html#id-new_connection
+#https://docs.zeek.org/en/v4.0.2/scripts/base/bif/event.bif.zeek.html#id-new_connection
 event new_connection(c: connection)
-@endif
         {
                 ConnPolling::watch(c, long_callback, 1, ALERT_INTERVAL);
         }


### PR DESCRIPTION
This PR switches the events used to track connection such that non-TCP connections are also tracked. 
Closes #3

For versions >= 3.1.0:
![image](https://user-images.githubusercontent.com/761220/122140551-d1367780-ce08-11eb-9b9b-fd065c88913d.png)
Otherwise:
![image](https://user-images.githubusercontent.com/761220/122140586-e7443800-ce08-11eb-940d-dd9b78d4a503.png)
