### PR TITLE
Add "open_ssl.log" to make it easier to correlate SSL data with open connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 By default, Zeek will only log connection information after the connection as been closed or Zeek has been stopped. This means that long running connections could run for hours, days, or even weeks before they are noticed. For threat hunters, this behavior is highly undesirable.
 
-This Zeek plugin will cause Zeek to periodically write out connection information for open connections. The information is written out to a file named "open_conn.log". The information written to the log file is identical to what is written to conn.log. Each entry contains the TOTAL duration and bytes transferred by the open connection.
+This Zeek plugin will cause Zeek to periodically write out connection information for open connections. The information is written out to two files named "open_conn.log" and "open_ssl.log". The information written to the log file is identical to what is written to conn.log and ssl.log. Each entry contains the TOTAL duration and bytes transferred by the open connection.
 
 The entries are written out at an interval that is specified by the user. The default interval is to write out an entry after the connection has been open for 1 hour and then every hour after that first hour.
 

--- a/scripts/zeek_open_connections.zeek
+++ b/scripts/zeek_open_connections.zeek
@@ -79,12 +79,12 @@ function long_callback(c: connection, cnt: count): interval
                 {
                 Conn::set_conn_log_data_hack(c);
                 Log::write(OpenConnection::LOG, c$conn);
-                        return ALERT_INTERVAL;
-                }
                 if ( c?$ssl && |c$ssl$server_name| > 0 )
                         {
                         Log::write(OpenConnection::SSL_LOG, c$ssl);
                         }
+                return ALERT_INTERVAL;
+                }
         else
                 return ALERT_INTERVAL - c$duration;
         }

--- a/scripts/zeek_open_connections.zeek
+++ b/scripts/zeek_open_connections.zeek
@@ -47,7 +47,7 @@ module OpenConnection;
 
 # Set this to the interval at which you want to alert on
 # open connections. 1hr means that an open connection will
-# be written to the conn_long log after 1hr has passed
+# be written to the open_conn log after 1hr has passed
 # and then every hour after that until it closes (2hrs, 3hrs, 4hrs, etc.).
 # Each time an entry is written, it contains the TOTAL duration and bytes
 # for the connection, not the incremental from the last entry. The information
@@ -55,7 +55,7 @@ module OpenConnection;
 const ALERT_INTERVAL = 1hr;
 
 export {
-        redef enum Log::ID += { LOG };
+        redef enum Log::ID += { LOG, SSL_LOG };
 
         redef enum Notice::Type += {
                 ## Notice for when a long connection is found.
@@ -65,14 +65,10 @@ export {
         };
 }
 
-redef record connection += {
-        ## Offset of the currently watched connection duration by the long-connections script.
-        long_conn_offset: count &default=0;
-};
-
 event zeek_init() &priority=5
         {
         Log::create_stream(LOG, [$columns=Conn::Info, $path="open_conn"]);
+        Log::create_stream(SSL_LOG, [$columns=SSL::Info, $path="open_ssl"]);
         }
 
 
@@ -85,6 +81,10 @@ function long_callback(c: connection, cnt: count): interval
                 Log::write(OpenConnection::LOG, c$conn);
                         return ALERT_INTERVAL;
                 }
+                if ( c?$ssl && |c$ssl$server_name| > 0 )
+                        {
+                        Log::write(OpenConnection::SSL_LOG, c$ssl);
+                        }
         else
                 return ALERT_INTERVAL - c$duration;
         }

--- a/zkg.meta
+++ b/zkg.meta
@@ -1,6 +1,6 @@
 [package]
 aliases = zeek-open-connections bro-open-connections
-description = Find and log open, long-lived connections into a "conn_long" log.
+description = Find and log open, long-lived connections into "open_conn" and "open_ssl" logs.
 tags = conn
 depends = zkg >=2.0.7
 version = 1.0


### PR DESCRIPTION
This PR instructs Zeek to write out the SSL details for each open connection if they exist to a new log file called "open_ssl.log". 
I tested this PR by changing the alert interval to `5sec`, copying this script over an existing Zeek 4.2.0 installation at `/opt/zeek/share/zeek/site/zeek_open_connections.zeek`, and reloading Zeek. Then, I opened an ssl connection with `openssl s_client irc.freenode.net:7070`. Afterwards, I ensured that the open_ssl.log contained the appropriate logs. 


Note: entries for open connections will be always be written to the normal ssl.log when the connection is initiated. However, cross correlating ssl data between the open_conn log and the original ssl log which may be in a previous day's dataset is difficult. 
These changes make correlating the ssl data with the open_conn data much easier. 

open_conn log:
```
#path	open_conn
#open	2023-04-01-00-08-00
#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	proto	service	duration	orig_bytes	resp_bytes	conn_state	local_orig	local_resp	missed_bytes	history	orig_pkts	orig_ip_bytes	resp_pkts	resp_ip_bytes	tunnel_parents
#types	time	string	addr	port	addr	port	enum	string	interval	count	count	string	bool	bool	count	string	count	count	count	count	set[string]

1680307688.401502	CT7P2e2I1qw5jqfsbg	192.168.3.40	43250	45.56.126.124	7070	tcp	ssl	7.597939	853	7084	S1	T	F	0ShADad	15	1641	17	7976	-
```

open_ssl log:
```
#path	open_ssl
#open	2023-04-01-00-08-16
#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	cipher	curve	server_name	resumed	last_alert	next_protocol	established	ssl_history	cert_chain_fps	client_cert_chain_fps	subject	issuer	client_subject	client_issuer	sni_matches_cert	validation_status	ja3	ja3s
#types	time	string	addr	port	addr	port	string	string	string	string	bool	string	string	bool	string	vector[string]	vector[string]	string	string	string	string	bool	string	string	string

1680307688.530764	CT7P2e2I1qw5jqfsbg	192.168.3.40	43250	45.56.126.124	7070	TLSv13	TLS_AES_256_GCM_SHA384	secp256r1	irc.freenode.net	F-	-	T	CsiICs	-	-	-	-	-	-	-	-	d8f7475ac699c7c5879b91fd373689ad	46ca3a127f5443353dfb8cc2e16197e5

```
