### PR TITLE
Add open_http log support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 By default, Zeek will only log connection information after the connection as been closed or Zeek has been stopped. This means that long running connections could run for hours, days, or even weeks before they are noticed. For threat hunters, this behavior is highly undesirable.
 
-This Zeek plugin will cause Zeek to periodically write out connection information for open connections. The information is written out to two files named "open_conn.log" and "open_ssl.log". The information written to the log file is identical to what is written to conn.log and ssl.log. Each entry contains the TOTAL duration and bytes transferred by the open connection.
+This Zeek plugin will cause Zeek to periodically write out connection information for open connections. The information is written out to three files named "open_conn.log", "open_ssl.log" and "open_http.log". The information written to these log files is identical to what is written to conn.log, ssl.log, and http.log. Each entry contains the TOTAL duration and bytes transferred by the open connection.
 
 The entries are written out at an interval that is specified by the user. The default interval is to write out an entry after the connection has been open for 1 hour and then every hour after that first hour.
 

--- a/scripts/zeek_open_connections.zeek
+++ b/scripts/zeek_open_connections.zeek
@@ -55,7 +55,7 @@ module OpenConnection;
 const ALERT_INTERVAL = 1hr;
 
 export {
-        redef enum Log::ID += { LOG, SSL_LOG };
+        redef enum Log::ID += { LOG, SSL_LOG, HTTP_LOG };
 
         redef enum Notice::Type += {
                 ## Notice for when a long connection is found.
@@ -69,6 +69,7 @@ event zeek_init() &priority=5
         {
         Log::create_stream(LOG, [$columns=Conn::Info, $path="open_conn"]);
         Log::create_stream(SSL_LOG, [$columns=SSL::Info, $path="open_ssl"]);
+        Log::create_stream(HTTP_LOG, [$columns=HTTP::Info, $path="open_http"]);
         }
 
 
@@ -79,6 +80,7 @@ function long_callback(c: connection, cnt: count): interval
                 {
                 Conn::set_conn_log_data_hack(c);
                 Log::write(OpenConnection::LOG, c$conn);
+                Log::write(OpenConnection::HTTP_LOG, c$http);
                 if ( c?$ssl && |c$ssl$server_name| > 0 )
                         {
                         Log::write(OpenConnection::SSL_LOG, c$ssl);

--- a/scripts/zeek_open_connections.zeek
+++ b/scripts/zeek_open_connections.zeek
@@ -80,7 +80,10 @@ function long_callback(c: connection, cnt: count): interval
                 {
                 Conn::set_conn_log_data_hack(c);
                 Log::write(OpenConnection::LOG, c$conn);
-                Log::write(OpenConnection::HTTP_LOG, c$http);
+                if ( c?$http )
+                        {
+	                Log::write(OpenConnection::HTTP_LOG, c$http);
+                        }
                 if ( c?$ssl && |c$ssl$server_name| > 0 )
                         {
                         Log::write(OpenConnection::SSL_LOG, c$ssl);

--- a/zkg.meta
+++ b/zkg.meta
@@ -1,6 +1,6 @@
 [package]
 aliases = zeek-open-connections bro-open-connections
-description = Find and log open, long-lived connections into "open_conn" and "open_ssl" logs.
+description = Find and log open, long-lived connections into "open_conn", "open_ssl", and "open_http" logs.
 tags = conn
 depends = zkg >=2.0.7
 version = 1.0


### PR DESCRIPTION
Tested, open_http.log created after the connection was open for more than an hour:

root@piub200464:/opt/zeek/logs/current# cat open_http.log 
#separator \x09
#set_separator	,
#empty_field	(empty)
#unset_field	-
#path	open_http
#open	2024-01-26-15-36-25
#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	trans_depth	method	host	uri	referrer	version	user_agent	origin	request_body_len	response_body_len	status_code	status_msg	info_code	info_msg	tags	username	password	proxied	orig_fuids	orig_filenames	orig_mime_types	resp_fuids	resp_filenames	resp_mime_types
#types	time	string	addr	port	addr	port	count	string	string	string	string	string	string	string	count	count	count	string	count	string	set[enum]	string	string	set[string]	vector[string]	vector[string]	vector[string]	vector[string]	vector[string]	vector[string]
1706297549.414490	CdG2s62GOe3E1UMUK5	10.0.0.238	58548	104.131.28.214	8000	1	GET	104.131.28.214:8000	/	-1.0	Lynx/2.9.0dev.5 libwww-FM/2.14 SSL-MM/1.4.1 GNUTLS/3.6.13	-	0	0	200	OK	-	-	(empty)	-	-FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl,FnRD3gTh44zYowZtl	-	text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json,text/json